### PR TITLE
Fix typo

### DIFF
--- a/spec/design/prior-art.md
+++ b/spec/design/prior-art.md
@@ -22,7 +22,7 @@ Finally, semantic web technologies do not inherently address security concerns. 
 
 With "personal data stores", individuals have control over their own personal data by storing it in a secure and private repository under their ownership and management. This approach aims to address concerns related to data privacy, security, and user control.
 
-Apps based on personal data stored give the user the freedom to switch between different apps or services without losing access to their valuable information. In practice, this also requires that the different apps can read (and maybe write) each other's data; to solve this, personal data stores must be combined with other approaches such as the semantic web.
+Apps based on personal data stores give the user the freedom to switch between different apps or services without losing access to their valuable information. In practice, this also requires that the different apps can read (and maybe write) each other's data; to solve this, personal data stores must be combined with other approaches such as the semantic web.
 
 While the concept of personal data stores primarily focuses on data ownership and control rather than user interfaces, it aligns with the principle of no attention theft indirectly. By enabling individuals to manage their personal data but switch apps at will, personal data stores empower users to have more control over their attention and limit the potential for attention-stealing practices.
 


### PR DESCRIPTION
Fixes a typo. The s and the d key are next to each other, and the mistaken word happens to be a real English word.

I do not know why the last line shows as being changed. I made the edit using the Github UI.